### PR TITLE
Add gimp-git/share/man to manpath.config

### DIFF
--- a/setup/dotfiles/install.sh
+++ b/setup/dotfiles/install.sh
@@ -17,4 +17,5 @@ if ! grep -q 'PREFIX' ~/.bashrc; then
 export PREFIX=/home/vagrant/gimp-git
 export PATH="\${PREFIX}/bin:\${PATH}"
 EOF
+  echo 'MANPATH_MAP /home/vagrant/gimp-git/bin /home/vagrant/gimp-git/share/man' | sudo tee -a /etc/manpath.config
 fi


### PR DESCRIPTION
This allows the manpage to be read when using `man gimp-2.9` for example.
