### PR TITLE
GIMP master build failures fixes #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ Plugin Development:
 * For Gtk+ dialogs see [GOjbect Introspection][gobject] and [Javascript
   implementations using GObject Introspection][jslibs].
 
+# More performance
+
+Currently the vagrant box is relatively low spec with the default 8MB video RAM,
+2048MB RAM, and 1 CPU core.  The `build-gimp.sh` script will automatically take
+advantage of more cores to build GIMP faster.  Just edit the
+[`Vagrant`](Vagrant) file and update the following settings.
+
+    # Customize the VM specs (memory values in MB)
+    vb.memory = "8192"
+    vb.customize ["modifyvm", :id, "--vram", "128"]
+    vb.cpus = "8"
+
 [gobject]: https://wiki.gnome.org/Projects/GObjectIntrospection
 [jsbind-idea]: http://wiki.gimp.org/wiki/Hacking:GSoC/2011/Ideas#Support_writing_JavaScript_plug-ins
 [jslibs]: https://wiki.gnome.org/JavaScript

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This repository assumes you already have [Vagrant installed][vagrant] and
 [VirtualBox installed][vbox].
 # Prerequisites
 
-* Install the [latest version of Vagrant][vagrant] (Vagrant 1.7.4 as of this
+* Install the [latest version of Vagrant][vagrant] (Vagrant 1.8.1 as of this
   writing).
-* Install the [latest version of VirtualBox][vbox] (VirtualBox 5.0.4 as of this
+* Install the [latest version of VirtualBox][vbox] (VirtualBox 5.0.10 as of this
   writing).
 
 # Provision development environment

--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ Plugin Development:
 * For Gtk+ dialogs see [GOjbect Introspection][gobject] and [Javascript
   implementations using GObject Introspection][jslibs].
 
-# More performance
+# Tips and Tricks
+
+### More performance
 
 Currently the vagrant box is relatively low spec with the default 8MB video RAM,
 2048MB RAM, and 1 CPU core.  The `build-gimp.sh` script will automatically take
@@ -99,6 +101,21 @@ advantage of more cores to build GIMP faster.  Just edit the
     vb.memory = "8192"
     vb.customize ["modifyvm", :id, "--vram", "128"]
     vb.cpus = "8"
+
+### Virtualbox Guest Additions
+
+Why virtualbox guest additions?  If you're using a graphical UI then it will
+autoscale when you fullscreen the virtual machine.  Shared clipboards can also
+be enabled.  These features are useful when developing software inside a VM.
+
+A script for installing Virtualbox guest additions has been provided.  From
+within the VM simply call:
+
+    /vagrant/setup/vbox-guest-additions/install.sh
+
+One can override the version of guest additions being installed.
+
+    vbox_version=5.0.12 /vagrant/setup/vbox-guest-additions/install.sh
 
 [gobject]: https://wiki.gnome.org/Projects/GObjectIntrospection
 [jsbind-idea]: http://wiki.gimp.org/wiki/Hacking:GSoC/2011/Ideas#Support_writing_JavaScript_plug-ins

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository assumes you already have [Vagrant installed][vagrant] and
 
 * Install the [latest version of Vagrant][vagrant] (Vagrant 1.8.1 as of this
   writing).
-* Install the [latest version of VirtualBox][vbox] (VirtualBox 5.0.10 as of this
+* Install the [latest version of VirtualBox][vbox] (VirtualBox 5.0.12 as of this
   writing).
 
 # Provision development environment

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(2) do |config|
   # For a complete reference, please see the online documentation at
   # https://docs.vagrantup.com.
 
-  version = "0.2"
+  version = "0.3"
   hostname = "gimpdev"
   locale = "en_US.UTF-8"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,8 +31,10 @@ Vagrant.configure(2) do |config|
     # Display the VirtualBox GUI when booting the machine
     vb.gui = true
 
-    # Customize the amount of memory on the VM:
+    # Customize the VM specs (memory values in MB)
     vb.memory = "2048"
+    #vb.customize ["modifyvm", :id, "--vram", "128"]
+    #vb.cpus = "8"
   end
   #
   # View the documentation for the provider you are using for more

--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -24,7 +24,9 @@ echo "vagrant:gimp" | chpasswd
 /build/tryscript.sh /build/gimp-packages/gimp-prereqs.sh
 /build/tryscript.sh /build/gimp-packages/babl-prereqs.sh
 /build/tryscript.sh /build/gimp-packages/gegl-prereqs.sh
+/build/tryscript.sh /build/libmypaint-packages/install.sh
 /build/gimp-source/install.sh
+/build/libmypaint-source/install.sh
 
 #a helpful message when a user logs in with vagrant ssh
 cp -f /build/motd /etc/

--- a/setup/dotfiles/install.sh
+++ b/setup/dotfiles/install.sh
@@ -16,6 +16,10 @@ if ! grep -q 'PREFIX' ~/.bashrc; then
 #gimp prefix
 export PREFIX=/home/vagrant/gimp-git
 export PATH="\${PREFIX}/bin:\${PATH}"
+
+#for GIMP packages and startup
+export PKG_CONFIG_PATH="\${PREFIX}/lib/pkgconfig:\${PKG_CONFIG_PATH}"
+export LD_LIBRARY_PATH="\${PREFIX}/lib:\${LD_LIBRARY_PATH}"
 EOF
   echo 'MANPATH_MAP /home/vagrant/gimp-git/bin /home/vagrant/gimp-git/share/man' | sudo tee -a /etc/manpath.config
 fi

--- a/setup/gimp-source/build-gimp.sh
+++ b/setup/gimp-source/build-gimp.sh
@@ -14,18 +14,21 @@ set -e
 export BABL_PREFIX="${PREFIX}"
 export GEGL_PREFIX="${PREFIX}"
 
+#parallelize number of threads based on number of available CPUs
+THREADS="$(nproc)"
+
 #build babl (a GIMP dependency) from latest master
 cd ~/git/babl
 mkdir -p ~/gimp-git/share/aclocal
 ./autogen.sh --prefix="${BABL_PREFIX}"
-make
-make install
+make -j${THREADS}
+make -j${THREADS} install
 
 #build gegl (a GIMP dependency) from latest master
 cd ~/git/gegl
 ./autogen.sh --prefix="${GEGL_PREFIX}"
-make
-make install
+make -j${THREADS}
+make -j${THREADS} install
 
 #build libmypaint (depends on GEGL and depended on by GIMP)
 cd ~/git/libmypaint
@@ -37,5 +40,5 @@ scons prefix="${PREFIX}" use_sharedlib=yes enable_gegl=true install
 #build GIMP from latest master
 cd ~/git/gimp
 ./autogen.sh --prefix="${PREFIX}"
-make
-make install
+make -j${THREADS}
+make -j${THREADS} install

--- a/setup/gimp-source/build-gimp.sh
+++ b/setup/gimp-source/build-gimp.sh
@@ -16,6 +16,7 @@ export GEGL_PREFIX="${PREFIX}"
 
 #build babl (a GIMP dependency) from latest master
 cd ~/git/babl
+mkdir -p ~/gimp-git/share/aclocal
 ./autogen.sh --prefix="${BABL_PREFIX}"
 make
 make install
@@ -25,6 +26,13 @@ cd ~/git/gegl
 ./autogen.sh --prefix="${GEGL_PREFIX}"
 make
 make install
+
+#build libmypaint (depends on GEGL and depended on by GIMP)
+cd ~/git/libmypaint
+#get the gegl version which was compiled and installed in ~/gimp-git; e.g. GEGL_VERSION=0.3
+export GEGL_VERSION="$(ls -l ~/gimp-git/lib/ | awk '$1 ~ /^d/ && $0 ~ /gegl/ { sub("gegl-", "", $NF); print $NF }')"
+scons prefix="${PREFIX}" use_sharedlib=yes enable_gegl=true
+scons prefix="${PREFIX}" use_sharedlib=yes enable_gegl=true install
 
 #build GIMP from latest master
 cd ~/git/gimp

--- a/setup/libmypaint-packages/install.sh
+++ b/setup/libmypaint-packages/install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+source /build/buildconfig
+echo "Install package dependencies for building libmypaint." 1>&2
+set -x
+
+#search for packages
+#apt-cache search <package>
+#get package versions
+#apt-cache policy <package>
+#install specific package version
+#apt-get install <package>=<version>
+
+#libmypaint dependencies
+DEPS=(
+scons
+libjson-c-dev
+)
+apt-get install ${DEPS[*]}

--- a/setup/libmypaint-source/install.sh
+++ b/setup/libmypaint-source/install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+source /build/buildconfig
+#do everything as vagrant user
+if [ ! "${USER}" = "vagrant" ]; then
+    su - vagrant -c "$0 $@"
+    exit
+fi
+echo "Cloning libmypaint sources (as vagrant user)." 1>&2
+set -x
+
+mkdir -p ~/git
+cd ~/git
+
+#clone sources
+#check to see if we can clone over git protocol (it may be blocked by firewall)
+#if blocked then fall back to using port 443 to clone projects
+if [ ! -e "libmypaint" ]; then
+  git clone "https://github.com/mypaint/libmypaint.git"
+fi

--- a/setup/vbox-guest-additions/install.sh
+++ b/setup/vbox-guest-additions/install.sh
@@ -4,7 +4,7 @@ source /build/buildconfig
 echo "Installing VirtualBox Guest Additions." 1>&2
 set -x
 
-export vbox_version="${vbox_version:-5.0.10}"
+export vbox_version="${vbox_version:-5.0.12}"
 
 if [ ! -e "/tmp/VBoxGuestAdditions_${vbox_version}.iso" ]; then
   echo 'Downloading guest additions.'


### PR DESCRIPTION
@scit2010 please review/test.  You can test with the following commands:

``` bash
cd path/to/vagrant-gimp
git fetch
git checkout gimp-update
#"vagrant destroy" if you already have a VM.
vagrant up
vagrant reload
vagrant ssh
#from within the VM
cd ~/git/gegl
git checkout 026bfb893da520548efcda4ebb18eb4f68e88be0
cd
./build-gimp.sh
```

I've added libmypaint as a dependency building from master based on the mailing list discussion linked in issue #10.

I had to check out gnome/gegl@026bfb893da520548efcda4ebb18eb4f68e88be0 since that was the [last successful build on `gegl-master`](https://build.gimp.org/job/gegl-master/).
